### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lambda-deploy.yml
+++ b/.github/workflows/lambda-deploy.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   ECR_REPOSITORY: grant-api
 


### PR DESCRIPTION
Potential fix for [https://github.com/disaenz/grant-api/security/code-scanning/3](https://github.com/disaenz/grant-api/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow does not appear to use the `GITHUB_TOKEN` directly, the permissions can be set to `contents: read` at the root level of the workflow. This ensures that the token has minimal access while maintaining functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
